### PR TITLE
Added lean node for strafe to fix gimble lock

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,10 @@ config/icon="res://icon.svg"
 
 Util="*res://scripts/util.gd"
 
+[dotnet]
+
+project/assembly_name="Proximal"
+
 [global_group]
 
 Player=""

--- a/scenes/Characters/player.tscn
+++ b/scenes/Characters/player.tscn
@@ -25,14 +25,16 @@ mesh = SubResource("CapsuleMesh_2hs0m")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.18267, 0)
 shape = SubResource("ConvexPolygonShape3D_1jxqw")
 
-[node name="Head" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.8, 0)
-
-[node name="Camera3D" type="Camera3D" parent="Head"]
-
-[node name="Weapon_Manager" parent="Head" instance=ExtResource("4_dqkch")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.291509, -0.296324, -0.453602)
-
 [node name="NavigationAgent3D" type="NavigationAgent3D" parent="."]
 
-[connection signal="dashInput" from="Head/Weapon_Manager" to="." method="_on_weapon_manager_dash_input"]
+[node name="LeanPivot" type="Node3D" parent="."]
+
+[node name="Head" type="Node3D" parent="LeanPivot"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.8, 0)
+
+[node name="Camera3D" type="Camera3D" parent="LeanPivot/Head"]
+
+[node name="Weapon_Manager" parent="LeanPivot/Head" instance=ExtResource("4_dqkch")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.291509, -0.296324, -0.453602)
+
+[connection signal="dashInput" from="LeanPivot/Head/Weapon_Manager" to="." method="_on_weapon_manager_dash_input"]

--- a/scripts/Characters/player.gd
+++ b/scripts/Characters/player.gd
@@ -37,9 +37,10 @@ const height = 1.8
 var current_strafe_dir = 0
 
 # nodes
-@onready var head := $Head
-@onready var camera := $Head/Camera3D
-@onready var weapon := $Head/Weapon_Manager
+@onready var lean_pivot := $LeanPivot
+@onready var head := $LeanPivot/Head
+@onready var camera := $LeanPivot/Head/Camera3D
+@onready var weapon := $LeanPivot/Head/Weapon_Manager
 
 
 
@@ -50,16 +51,16 @@ func _input(event: InputEvent) -> void:
 		Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 	elif event.is_action_pressed("ui_cancel"):
 		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-	if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
-		if event is InputEventMouseMotion:
-			if current_state == INPUT_STATE.normal:
-				rotate_y(deg_to_rad(-event.relative.x * MOUSE_SENS))
-				head.rotate_x(deg_to_rad(-event.relative.y * MOUSE_SENS))
-				head.rotation.x = clamp(head.rotation.x, deg_to_rad(-75), deg_to_rad(80))
+		
+	if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED and event is InputEventMouseMotion:
+		if current_state == INPUT_STATE.normal:
+			rotate_y(deg_to_rad(-event.relative.x * MOUSE_SENS)) # yaw
+			head.rotate_x(deg_to_rad(-event.relative.y * MOUSE_SENS)) # pitch
+			head.rotation.x = clamp(head.rotation.x, deg_to_rad(-75), deg_to_rad(80))
 
 # frame by frame
 func _process(delta: float):
-	head.rotation.z = lerp(head.rotation.z, current_strafe_dir * LEAN_MULT, delta * LEAN_SMOOTH) # this causes some weirdness when you look down/up, working on a fix
+	lean_pivot.rotation.z = lerp(lean_pivot.rotation.z, current_strafe_dir * LEAN_MULT, delta * LEAN_SMOOTH) # this causes some weirdness when you look down/up, working on a fix
 
 # frame by frame physics
 func _physics_process(delta: float) -> void:


### PR DESCRIPTION
Player Camera:
- If you keep moving the mouse down while looking down, eventually the player camera will invert itself, causing gameplay controls to also be inverted.
```
How to replicate:
1. Start game instance.
2. Look down; when the camera stops, keep dragging the mouse down.
3. Eventually, the camera will invert itself; continuing to drag down will correct it, but the movement system will have rotated.
```
Fixed:
- Added LeanPivot node to solely handle strafe lean.